### PR TITLE
chore: explicitly supply stage to serverless deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "echo \"unit tests have not been implemented\"",
     "build": "sls package",
-    "deploy": "sls deploy"
+    "deploy": "sls deploy --stage dev"
   },
   "dependencies": {
     "jsonwebtoken": "^8.5.1",


### PR DESCRIPTION
we need to supply the stage explicitly or else the cloudformation stack fails to update the api key